### PR TITLE
Generics

### DIFF
--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -21,6 +21,7 @@ export class Cluster extends Node<Cluster> {
 
   constructor(cluster: string, noSequence: boolean = false) {
     super();
+    this.value = this;
     this.#original = cluster;
     this.#sequenced = this.sequence(noSequence);
   }

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -15,7 +15,7 @@ import { charToNameMap, CharToNameMap, NameToCharMap, nameToCharMap } from "./ut
  * Because Hebrew orthography is both sub and supra linear, clusters can be encoded in various ways.
  * Every [[`Char`]] is sequenced first for normalization, see the [SBL Hebrew Font Manual](https://www.sbl-site.org/Fonts/SBLHebrewUserManual1.5x.pdf), p.8.
  */
-export class Cluster extends Node {
+export class Cluster extends Node<Cluster> {
   #original: string;
   #sequenced: Char[];
 

--- a/src/node.ts
+++ b/src/node.ts
@@ -1,21 +1,21 @@
-export class Node {
-  next: Node | null;
-  prev: Node | null;
-  protected child!: Node;
+export class Node<T> {
+  next: Node<T> | null;
+  prev: Node<T> | null;
+  protected child!: Node<T>;
 
   constructor() {
     this.next = null;
     this.prev = null;
   }
 
-  protected set children(arr: Node[]) {
+  protected set children(arr: Node<T>[]) {
     const head = arr[0];
     const remainder = arr.slice(1);
     this.child = head;
     head.siblings = remainder;
   }
 
-  set siblings(arr: Node[]) {
+  set siblings(arr: Node<T>[]) {
     const len = arr.length;
     for (let index = 0; index < len; index++) {
       const curr = arr[index];
@@ -27,7 +27,7 @@ export class Node {
     }
   }
 
-  get siblings(): Node[] {
+  get siblings(): Node<T>[] {
     let curr = this.next;
     const res = [];
     while (curr) {

--- a/src/node.ts
+++ b/src/node.ts
@@ -1,9 +1,11 @@
 export class Node<T> {
   next: Node<T> | null;
   prev: Node<T> | null;
+  value: T | null;
   protected child!: Node<T>;
 
   constructor() {
+    this.value = null;
     this.next = null;
     this.prev = null;
   }

--- a/src/syllable.ts
+++ b/src/syllable.ts
@@ -43,6 +43,7 @@ export class Syllable extends Node<Syllable> {
    */
   constructor(clusters: Cluster[], { isClosed = false, isAccented = false, isFinal = false } = {}) {
     super();
+    this.value = this;
     this.#clusters = clusters;
     this.#isClosed = isClosed;
     this.#isAccented = isAccented;

--- a/src/syllable.ts
+++ b/src/syllable.ts
@@ -27,7 +27,7 @@ const sylNameToCharMap: SyllableNameToCharMap = {
 /**
  * A `Syllable` is created from an array of [[`Clusters`]].
  */
-export class Syllable extends Node {
+export class Syllable extends Node<Syllable> {
   #clusters: Cluster[];
   #isClosed: boolean;
   #isAccented: boolean;


### PR DESCRIPTION
Closes #98 

While calling `next` or `prev` won't get type-safety, now you can call `value` to get the object of `next` and `prev`.

Example:

```ts
const str = `כּוֹרֶשׁ כּ֫וֹרֶשׁ`;
const text = new Text(str);
const syllable = text.syllables[0]; // is a Syllable
const next = syllable.next; // no Syllable types, only Node types (i.e. prev, next, siblings)
const nextSyl = next?.value // is a Syllable
console.log(nextSyl?.text); // "רֶשׁ"
```