### PR TITLE
Add qamets qatan when 'kol' is by itself

### DIFF
--- a/src/utils/qametsQatan.ts
+++ b/src/utils/qametsQatan.ts
@@ -65,8 +65,8 @@ const wholeWords = [
   "^יָמִים$",
   "(מִ)?כָּל־", // kol w/ maqqef optionally preceded by mem
   "(וּבְ|וְ|בְּ|לְ)?כָל־", // kol w/ maqqef optionally preceded by shureq + bet, waw, bet, or lamed
-  "^(מִ)?כָּל $", // kol w/o maqqef optionally preceded by mem
-  "^(וּבְ|וְ|בְּ|לְ)?כָל $", // kol w/o maqqef optionally preceded by shureq + bet, waw, bet, or lamed
+  "^(מִ)?כָּל ?$", // kol w/o maqqef optionally preceded by mem
+  "^(וּבְ|וְ|בְּ|לְ)?כָל ?$", // kol w/o maqqef optionally preceded by shureq + bet, waw, bet, or lamed
   "מָר־",
   "עָתְנִיאֵל",
   "רָב־",

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -131,6 +131,18 @@ describe.each`
   ${"kol w/o maqqef + bet prefix"}          | ${"בְּכָל לְבַבְכֶ֖ם"}     | ${false}  | ${true}   | ${false}
   ${"kol w/o maqqef + lamed prefix"}        | ${"לְכָל חֵ֖פֶץ"}          | ${true}   | ${false}  | ${true}
   ${"kol w/o maqqef + lamed prefix"}        | ${"לְכָל חֵ֖פֶץ"}          | ${false}  | ${true}   | ${false}
+  ${"kol alone"}                            | ${"כָּל"}           | ${true}   | ${false}  | ${true}
+  ${"kol alone"}                            | ${"כָּל"}           | ${false}  | ${true}   | ${false}
+  ${"kol alone + mem prefix"}               | ${"מִכָּל"}     | ${true}   | ${false}  | ${true}
+  ${"kol alone + mem prefix"}               | ${"מִכָּל"}     | ${false}  | ${true}   | ${false}
+  ${"kol alone + waw prefix"}               | ${"וְכָל"}         | ${true}   | ${false}  | ${true}
+  ${"kol alone + waw prefix"}               | ${"וְכָל"}         | ${false}  | ${true}   | ${false}
+  ${"kol alone + shureq & bet prefix"}      | ${"וּבְכָל"}  | ${true}   | ${false}  | ${true}
+  ${"kol alone + shureq & bet prefix"}      | ${"וּבְכָל"}  | ${false}  | ${true}   | ${false}
+  ${"kol alone + bet prefix"}               | ${"בְּכָל"}     | ${true}   | ${false}  | ${true}
+  ${"kol alone + bet prefix"}               | ${"בְּכָל"}     | ${false}  | ${true}   | ${false}
+  ${"kol alone + lamed prefix"}             | ${"לְכָל"}          | ${true}   | ${false}  | ${true}
+  ${"kol alone + lamed prefix"}             | ${"לְכָל"}          | ${false}  | ${true}   | ${false}
 `("qametsQatan:", ({ description, word, hasQamQat, hasQamets, qamQatOpt }) => {
   const text = new Text(word, { qametsQatan: qamQatOpt });
   const sanitized = text.text;


### PR DESCRIPTION
I noticed that the current qamets qatan regex for 'kol' doesn't handle the case when it is by itself (i.e. doesn't precede another word). This doesn't come up in practice, of course, but it did confuse me and make me think that the qamets qatan conversion didn't work when I typed in just "כָּל" as a test in [hebrewtransliteration.app](hebrewtransliteration.app).

This PR makes the whitespace in that regex optional, which fixes this issue, and adds some tests.

(BTW I just found this project, it's amazing!)