### PR TITLE
Make `isShureq` accurate

### DIFF
--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -86,7 +86,7 @@ export class Cluster extends Node<Cluster> {
   }
 
   /**
-   * Returns `true` if `Cluster.hasVowel`, `Cluster.hasSheva`, and, `Cluster.isShureq` are all `false` and `Cluster.text` contains a:
+   * Returns `true` if `Cluster.hasVowel`, `Cluster.hasSheva`, `Cluster.isShureq`, and `Cluster.next.isShureq` are all `false` and `Cluster.text` contains a:
    * - `ה` preceded by a qamets, tsere, or segol
    * - `ו` preceded by a holem
    * - `י` preceded by a hiriq, tsere, or segol
@@ -160,7 +160,7 @@ export class Cluster extends Node<Cluster> {
 
   /**
    *
-   * Returns `true` if `Cluster.hasVowel` is `false` and `Cluster.text` is a waw followed by a dagesh (e.g. `וּ`)
+   * Returns `true` if `Cluster.hasVowel`, `Cluster.hasSheva`, and `Cluster.prev.hasVowel` are all `false` and `Cluster.text` is a waw followed by a dagesh (e.g. `וּ`)
    * A shureq is a vowel itself, but contains no vowel characters (hence why `hasVowel` cannot be `true`).
    * This allows for easier syllabification.
    *
@@ -174,7 +174,8 @@ export class Cluster extends Node<Cluster> {
    */
   get isShureq(): boolean {
     const shureq = /\u{05D5}\u{05BC}/u;
-    return !this.hasVowel ? shureq.test(this.text) : false;
+    const prvHasVowel = this.prev instanceof Cluster && this.prev.hasVowel;
+    return !this.hasVowel && !this.hasSheva && !prvHasVowel ? shureq.test(this.text) : false;
   }
 
   /**

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -174,7 +174,7 @@ export class Cluster extends Node<Cluster> {
    */
   get isShureq(): boolean {
     const shureq = /\u{05D5}\u{05BC}/u;
-    const prvHasVowel = this.prev instanceof Cluster && this.prev.hasVowel;
+    const prvHasVowel = this.prev?.value?.hasVowel ?? false;
     return !this.hasVowel && !this.hasSheva && !prvHasVowel ? shureq.test(this.text) : false;
   }
 

--- a/test/cluster.test.ts
+++ b/test/cluster.test.ts
@@ -155,3 +155,22 @@ describe.each`
     });
   });
 });
+
+describe.each`
+  description                                 | hebrew         | clusterNum | isShureq
+  ${"mid-word shureq"}                        | ${"קוּם"}      | ${1}       | ${true}
+  ${"mid-word vav dagesh with vowel"}         | ${"שִׁוֵּק"}   | ${1}       | ${false}
+  ${"mid-word vav dagesh with vowel before"}  | ${"שִׁוּוּק"}  | ${1}       | ${false}
+  ${"mid-word shureq with vav dagesh before"} | ${"שִׁוּוּק"}  | ${2}       | ${true}
+  ${"mid-word vav dagesh with sheva"}         | ${"מְצַוְּךָ"} | ${2}       | ${false}
+  ${"final vav dagesh with vowel before"}     | ${"גֵּוּ"}     | ${1}       | ${false}
+`("isShureq:", ({ description, hebrew, clusterNum, isShureq }) => {
+  const heb = new Text(hebrew);
+  const cluster = heb.clusters[clusterNum];
+  const meteg = cluster.isShureq;
+  describe(description, () => {
+    test(`isShureq to equal ${isShureq}`, () => {
+      expect(meteg).toEqual(isShureq);
+    });
+  });
+});


### PR DESCRIPTION
Currently, `isShureq` only checks whether the cluster has a vowel, which incorrectly labels clusters with a vocal sheva (e.g. the third cluster of מְצַוְּךָ) and clusters with a preceding vowel (e.g. the second cluster of גֵּוּ) as shureqs.

This is important because if `DAGESH_CHAZAQ` is set to `false` in [hebrew-transliteration](https://github.com/charlesLoder/hebrew-transliteration), then `isShureq` is called to determine whether to transliterate the cluster as a `SHUREQ`. For example, currently:
```javascript
transliterate("גֵּוּ", {DAGESH_CHAZAQ: false}) === "gēû"
transliterate("מְצַוְּךָּ", {DAGESH_CHAZAQ: false}) === "mǝṣaûǝkā"
```
where they should be `"gēw"` and `"mǝṣawǝkā"`, respectively, to match their versions with `DAGESH_CHAZAQ` set to `true` (i.e. `"gēww"` and `"mǝṣawwǝkā"`).

I also added some tests, with a few of the example words taken from these Wikipedia pages: [[1]](https://en.wikipedia.org/wiki/Romanization_of_Hebrew#cite_note-note_vav_dgusha-12) [[2]](https://en.wikipedia.org/wiki/Kubutz_and_shuruk#Appearance)