### PR TITLE
Syllable structure

### DIFF
--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -86,7 +86,7 @@ export class Cluster extends Node<Cluster> {
   }
 
   /**
-   * Returns `true` if `Cluster.hasVowel`, `Cluster.hasSheva`, and, `Cluster.isShureq` are all `false` and `Cluster.text` contains a:
+   * Returns `true` if `Cluster.hasVowel`, `Cluster.hasSheva`, `Cluster.isShureq`, and `Cluster.next.isShureq` are all `false` and `Cluster.text` contains a:
    * - `ה` preceded by a qamets, tsere, or segol
    * - `ו` preceded by a holem
    * - `י` preceded by a hiriq, tsere, or segol
@@ -160,7 +160,7 @@ export class Cluster extends Node<Cluster> {
 
   /**
    *
-   * Returns `true` if `Cluster.hasVowel` is `false` and `Cluster.text` is a waw followed by a dagesh (e.g. `וּ`)
+   * Returns `true` if `Cluster.hasVowel`, `Cluster.hasSheva`, and `Cluster.prev.hasVowel` are all `false` and `Cluster.text` is a waw followed by a dagesh (e.g. `וּ`)
    * A shureq is a vowel itself, but contains no vowel characters (hence why `hasVowel` cannot be `true`).
    * This allows for easier syllabification.
    *
@@ -174,7 +174,8 @@ export class Cluster extends Node<Cluster> {
    */
   get isShureq(): boolean {
     const shureq = /\u{05D5}\u{05BC}/u;
-    return !this.hasVowel ? shureq.test(this.text) : false;
+    const prvHasVowel = this.prev instanceof Cluster && this.prev.hasVowel;
+    return !this.hasVowel && !this.hasSheva && !prvHasVowel ? shureq.test(this.text) : false;
   }
 
   /**

--- a/src/syllable.ts
+++ b/src/syllable.ts
@@ -271,12 +271,14 @@ export class Syllable extends Node<Syllable> {
     // Initial shureq: If the syllable starts with a shureq, then it has no
     // onset, its nucleus is the shureq, and its coda is any remaining clusters
     if (heClusters[0].isShureq) {
-      const nucleus = heClusters[0].text;
-      const coda = heClusters
-        .slice(1)
-        .map((c) => c.text)
-        .join("");
-      return ["", nucleus, coda];
+      return [
+        "",
+        heClusters[0].text,
+        heClusters
+          .slice(1)
+          .map((c) => c.text)
+          .join("")
+      ];
     }
     // Furtive patah: If the syllable is final and is either a het, ayin, or he
     // (with dagesh) followed by a patah, then it has no onset, its nucleus is

--- a/src/syllable.ts
+++ b/src/syllable.ts
@@ -324,7 +324,7 @@ export class Syllable extends Node<Syllable> {
       .map((c) => c.text)
       .join("");
     // (handle gemination)
-    if (withGemination && coda.length === 0 && !/\u{05B0}/.test(nucleus)) {
+    if (withGemination && coda.length === 0 && !/\u{05B0}/u.test(nucleus)) {
       if (this.next instanceof Syllable) {
         const nextOnset = this.next.onset;
         if (/\u{05BC}/u.test(nextOnset)) {

--- a/test/cluster.test.ts
+++ b/test/cluster.test.ts
@@ -155,3 +155,22 @@ describe.each`
     });
   });
 });
+
+describe.each`
+  description                                 | hebrew         | clusterNum | isShureq
+  ${"mid-word shureq"}                        | ${"קוּם"}      | ${1}       | ${true}
+  ${"mid-word vav dagesh with vowel"}         | ${"שִׁוֵּק"}   | ${1}       | ${false}
+  ${"mid-word vav dagesh with vowel before"}  | ${"שִׁוּוּק"}  | ${1}       | ${false}
+  ${"mid-word shureq with vav dagesh before"} | ${"שִׁוּוּק"}  | ${2}       | ${true}
+  ${"mid-word vav dagesh with sheva"}         | ${"מְצַוְּךָ"} | ${2}       | ${false}
+  ${"final vav dagesh with vowel before"}     | ${"גֵּוּ"}     | ${1}       | ${false}
+`("isShureq:", ({ description, hebrew, clusterNum, isShureq }) => {
+  const heb = new Text(hebrew);
+  const cluster = heb.clusters[clusterNum];
+  const meteg = cluster.isShureq;
+  describe(description, () => {
+    test(`isShureq to equal ${isShureq}`, () => {
+      expect(meteg).toEqual(isShureq);
+    });
+  });
+});

--- a/test/syllable.test.ts
+++ b/test/syllable.test.ts
@@ -66,6 +66,49 @@ describe.each`
 });
 
 describe.each`
+  description                                  | hebrew             | syllableNum | onset   | nucleus               | coda
+  ${"closed syllable"}                         | ${"יָ֥ם"}          | ${0}        | ${"י"}  | ${"\u{05B8}\u{05A5}"} | ${"ם"}
+  ${"open syllable"}                           | ${"מַדּוּעַ"}      | ${0}        | ${"מ"}  | ${"\u{05B7}"}         | ${""}
+  ${"syllable with shureq"}                    | ${"מַדּוּעַ"}      | ${1}        | ${"דּ"} | ${"וּ"}               | ${""}
+  ${"syllable with furtive patah"}             | ${"מַדּוּעַ"}      | ${2}        | ${""}   | ${"\u{05B7}"}         | ${"ע"}
+  ${"word-initial shureq"}                     | ${"וּמֶלֶךְ"}      | ${0}        | ${""}   | ${"וּ"}               | ${""}
+  ${"onset cluster (not supported)"}           | ${"שְׁתַּיִם"}     | ${0}        | ${"שׁ"} | ${"\u{05B0}"}         | ${""}
+  ${"Jerusalem w/ patah penultimate syllable"} | ${"יְרוּשָׁלִַ֗ם"} | ${3}        | ${"ל"}  | ${"\u{05B7}\u{0597}"} | ${""}
+  ${"Jerusalem w/ patah final syllable"}       | ${"יְרוּשָׁלִַ֗ם"} | ${4}        | ${""}   | ${"\u{05B4}"}         | ${"ם"}
+`("structure:", ({ description, hebrew, syllableNum, onset, nucleus, coda }) => {
+  const heb = new Text(hebrew);
+  const syllable = heb.syllables[syllableNum];
+  const [syllableOnset, syllableNucleus, syllableCoda] = syllable.structure();
+  describe(description, () => {
+    test(`onset to equal ${onset}`, () => {
+      expect(syllableOnset).toEqual(onset);
+    });
+    test(`nucleus to equal ${nucleus}`, () => {
+      expect(syllableNucleus).toEqual(nucleus);
+    });
+    test(`coda to equal ${coda}`, () => {
+      expect(syllableCoda).toEqual(coda);
+    });
+  });
+});
+
+describe.each`
+  description                                  | hebrew        | syllableNum | codaWithGemination
+  ${"open syllable followed by gemination"}    | ${"מַדּוּעַ"} | ${0}        | ${"דּ"}
+  ${"open syllable followed by no gemination"} | ${"מֶלֶךְ"}   | ${0}        | ${""}
+  ${"closed syllable followed by dagesh qal"}  | ${"מַסְגֵּר"} | ${0}        | ${"סְ"}
+`("codaWithGemination:", ({ description, hebrew, syllableNum, codaWithGemination }) => {
+  const heb = new Text(hebrew);
+  const syllable = heb.syllables[syllableNum];
+  const syllableCodaWithGemination = syllable.codaWithGemination;
+  describe(description, () => {
+    test(`codaWithGemination to equal ${codaWithGemination}`, () => {
+      expect(syllableCodaWithGemination).toEqual(codaWithGemination);
+    });
+  });
+});
+
+describe.each`
   description               | hebrew                 | syllableNum | nextExists | nextText
   ${"has next"}             | ${"הַֽ֭יְחָבְרְךָ"}    | ${0}        | ${true}    | ${"יְ"}
   ${"does not have next"}   | ${"כִּסֵּ֣א"}          | ${1}        | ${false}   | ${null}

--- a/test/syllable.test.ts
+++ b/test/syllable.test.ts
@@ -93,10 +93,11 @@ describe.each`
 });
 
 describe.each`
-  description                                  | hebrew        | syllableNum | codaWithGemination
-  ${"open syllable followed by gemination"}    | ${"מַדּוּעַ"} | ${0}        | ${"דּ"}
-  ${"open syllable followed by no gemination"} | ${"מֶלֶךְ"}   | ${0}        | ${""}
-  ${"closed syllable followed by dagesh qal"}  | ${"מַסְגֵּר"} | ${0}        | ${"סְ"}
+  description                                          | hebrew         | syllableNum | codaWithGemination
+  ${"open syllable followed by gemination"}            | ${"מַדּוּעַ"}  | ${0}        | ${"דּ"}
+  ${"open syllable followed by no gemination"}         | ${"מֶלֶךְ"}    | ${0}        | ${""}
+  ${"closed syllable followed by dagesh qal"}          | ${"מַסְגֵּר"}  | ${0}        | ${"סְ"}
+  ${"open syllable with sheva followed by dagesh qal"} | ${"שְׁתַּיִם"} | ${0}        | ${""}
 `("codaWithGemination:", ({ description, hebrew, syllableNum, codaWithGemination }) => {
   const heb = new Text(hebrew);
   const syllable = heb.syllables[syllableNum];


### PR DESCRIPTION
*NB: This PR builds off #113 so should not be merged until the former is reviewed and/or merged.*

This PR adds `onset`, `nucleus`, and `coda` methods to the `Syllable` class and appropriate tests to `syllable.test.ts`. These methods are exactly as described in #2 (with the exception that they return `""` instead of `null`).

This PR also adds `codaWithGemination`, which includes gemination of the subsequent syllable in the coda. This is inspired by my comment in https://github.com/charlesLoder/hebrew-transliteration/discussions/68.

Note that currently the onset of the first syllable of שְׁתַּיִם is not `"שְׁתּ"`, as it ought to be, since this library syllabifies שְׁתַּיִם as `["שְׁ", "תַּ", "יִם"]`.

Resolves #2