### PR TITLE
Parent object

### DIFF
--- a/src/char.ts
+++ b/src/char.ts
@@ -1,3 +1,4 @@
+import { Cluster } from "./cluster";
 import { taamim } from "./utils/regularExpressions";
 const consonants = /[\u{05D0}-\u{05F2}]/u;
 const ligature = /[\u{05C1}-\u{05C2}]/u;
@@ -10,6 +11,7 @@ const niqqud = /[\u{05B0}-\u{05BB}\u{05C7}]/u;
  */
 export class Char {
   #text: string;
+  #cluster: Cluster | null = null;
 
   constructor(char: string) {
     this.#text = char;
@@ -68,5 +70,25 @@ export class Char {
    */
   get sequencePosition(): number {
     return this.findPos();
+  }
+
+  /**
+   * The parent `Cluster` of the `Char`, if any.
+   *
+   * ```typescript
+   * const text: Text = new Text("דָּבָר");
+   * const firstChar = text.chars[0];
+   * firstChar.text;
+   * // "ד"
+   * firstChar.cluster?.text;
+   * // "דָּ"
+   * ```
+   */
+  get cluster(): Cluster | null {
+    return this.#cluster;
+  }
+
+  set cluster(cluster: Cluster | null) {
+    this.#cluster = cluster;
   }
 }

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -1,5 +1,6 @@
 import { Char } from "./char";
 import { Node } from "./node";
+import { Syllable } from "./syllable";
 import { taamim, hebChars, vowelsCaptureGroup, punctuation } from "./utils/regularExpressions";
 import { charToNameMap, CharToNameMap, NameToCharMap, nameToCharMap } from "./utils/vowelMap";
 
@@ -18,12 +19,14 @@ import { charToNameMap, CharToNameMap, NameToCharMap, nameToCharMap } from "./ut
 export class Cluster extends Node<Cluster> {
   #original: string;
   #sequenced: Char[];
+  #syllable: Syllable | null = null;
 
   constructor(cluster: string, noSequence: boolean = false) {
     super();
     this.value = this;
     this.#original = cluster;
     this.#sequenced = this.sequence(noSequence);
+    this.#sequenced.forEach((char) => (char.cluster = this));
   }
 
   /**
@@ -409,6 +412,26 @@ export class Cluster extends Node<Cluster> {
   hasVowelName(name: keyof NameToCharMap): boolean {
     if (!nameToCharMap[name]) throw new Error(`${name} is not a valid value`);
     return this.text.indexOf(nameToCharMap[name]) !== -1 ? true : false;
+  }
+
+  /**
+   * The parent `Syllable` of the cluster, if any.
+   *
+   * ```typescript
+   * const text: Text = new Text("דָּבָר");
+   * const lastCluster: Cluster = text.clusters[2];
+   * lastCluster.text;
+   * // "ר"
+   * lastCluster.syllable.text;
+   * // "בָר"
+   * ```
+   */
+  get syllable(): Syllable | null {
+    return this.#syllable;
+  }
+
+  set syllable(syllable: Syllable | null) {
+    this.#syllable = syllable;
   }
 
   /**

--- a/src/syllable.ts
+++ b/src/syllable.ts
@@ -3,6 +3,7 @@ import { Char } from "./char";
 import { CharToNameMap, charToNameMap, NameToCharMap, nameToCharMap } from "./utils/vowelMap";
 import { vowelsCaptureGroupWithSheva } from "./utils/regularExpressions";
 import { Node } from "./node";
+import { Word } from "./word";
 
 interface SyllableCharToNameMap extends CharToNameMap {
   /* eslint-disable  @typescript-eslint/naming-convention */
@@ -32,6 +33,7 @@ export class Syllable extends Node<Syllable> {
   #isClosed: boolean;
   #isAccented: boolean;
   #isFinal: boolean;
+  #word: Word | null = null;
 
   /**
    *
@@ -365,5 +367,13 @@ export class Syllable extends Node<Syllable> {
    */
   get codaWithGemination(): string {
     return this.structure(true)[2];
+  }
+
+  get word(): Word | null {
+    return this.#word;
+  }
+
+  set word(word: Word | null) {
+    this.#word = word;
   }
 }

--- a/src/utils/syllabifier.ts
+++ b/src/utils/syllabifier.ts
@@ -441,5 +441,8 @@ export const syllabify = (clusters: Cluster[], options: SylOpts): Syllable[] => 
   syllables[syllables.length - 1].isFinal = true;
   syllables.forEach(setIsClosed);
   syllables.forEach(setIsAccented);
+
+  // for each cluster, set its syllable
+  syllables.forEach((s) => s.clusters.forEach((c) => (c.syllable = s)));
   return latinClusters.length ? reinsertLatin(syllables, latinClusters) : syllables;
 };

--- a/src/word.ts
+++ b/src/word.ts
@@ -138,10 +138,14 @@ export class Word {
   get syllables(): Syllable[] {
     if (/\w/.test(this.text) || this.isDivineName || this.isNotHebrew) {
       const syl = new Syllable(this.clusters);
+      syl.word = this;
       return [syl];
     }
 
-    return syllabify(this.clusters, this.sylOpts);
+    const syllables = syllabify(this.clusters, this.sylOpts);
+    syllables.forEach((syl) => (syl.word = this));
+
+    return syllables;
   }
 
   /**

--- a/test/char.test.ts
+++ b/test/char.test.ts
@@ -1,0 +1,16 @@
+import { Text } from "../src/index";
+import { Char } from "../src/char";
+
+describe("cluster:", () => {
+  test("if no cluster, null", () => {
+    const char = new Char("ד");
+    expect(char.cluster).toEqual(null);
+  });
+
+  test("ensure cluster text matches", () => {
+    const text = new Text("דָּבָר");
+    const firstChar = text.chars[0];
+    const firstCluster = text.clusters[0];
+    expect(firstChar.cluster?.text).toEqual(firstCluster.text);
+  });
+});

--- a/test/cluster.test.ts
+++ b/test/cluster.test.ts
@@ -1,6 +1,60 @@
 import { Text } from "../src/index";
 
 describe.each`
+  description                                        | hebrew              | clusterNum | hasMeteg
+  ${"word with single meteg"}                        | ${"הַֽ֭יְחָבְרְךָ"} | ${0}       | ${true}
+  ${"word with single silluq"}                       | ${"נַפְשִֽׁי׃"}     | ${2}       | ${false}
+  ${"word with meteg & silluq"}                      | ${"הָֽאֲדָמָֽה׃"}   | ${0}       | ${true}
+  ${"word with meteg & silluq"}                      | ${"הָֽאֲדָמָֽה׃"}   | ${3}       | ${false}
+  ${"words with meteg & silluq, joined with maqqef"} | ${"וַֽיְהִי־כֵֽן׃"} | ${0}       | ${true}
+  ${"words with meteg & silluq, joined with maqqef"} | ${"וַֽיְהִי־כֵֽן׃"} | ${5}       | ${false}
+`("hasMeteg:", ({ description, hebrew, clusterNum, hasMeteg }) => {
+  const heb = new Text(hebrew);
+  const cluster = heb.clusters[clusterNum];
+  const meteg = cluster.hasMeteg;
+  describe(description, () => {
+    test(`hasMeteg to equal ${hasMeteg}`, () => {
+      expect(meteg).toEqual(hasMeteg);
+    });
+  });
+});
+
+describe.each`
+  description                                        | hebrew              | clusterNum | hasSilluq
+  ${"word with single meteg"}                        | ${"הַֽ֭יְחָבְרְךָ"} | ${0}       | ${false}
+  ${"word with single silluq"}                       | ${"נַפְשִֽׁי׃"}     | ${2}       | ${true}
+  ${"word with meteg & silluq"}                      | ${"הָֽאֲדָמָֽה׃"}   | ${0}       | ${false}
+  ${"word with meteg & silluq"}                      | ${"הָֽאֲדָמָֽה׃"}   | ${3}       | ${true}
+  ${"words with meteg & silluq, joined with maqqef"} | ${"וַֽיְהִי־כֵֽן׃"} | ${0}       | ${false}
+  ${"words with meteg & silluq, joined with maqqef"} | ${"וַֽיְהִי־כֵֽן׃"} | ${5}       | ${true}
+`("hasSilluq:", ({ description, hebrew, clusterNum, hasSilluq }) => {
+  const heb = new Text(hebrew);
+  const cluster = heb.clusters[clusterNum];
+  const silluq = cluster.hasSilluq;
+  describe(description, () => {
+    test(`hasSilluq to equal ${hasSilluq}`, () => {
+      expect(silluq).toEqual(hasSilluq);
+    });
+  });
+});
+
+describe.each`
+  description                | hebrew              | clusterNum | vowelName   | result
+  ${"cluster with patah"}    | ${"הַֽ֭יְחָבְרְךָ"} | ${0}       | ${"PATAH"}  | ${true}
+  ${"cluster with qamets"}   | ${"הַֽ֭יְחָבְרְךָ"} | ${0}       | ${"QAMATS"} | ${false}
+  ${"cluster with no vowel"} | ${"י֔וֹם"}          | ${2}       | ${"HOLAM"}  | ${false}
+`("hasVowelName:", ({ description, hebrew, clusterNum, vowelName, result }) => {
+  const heb = new Text(hebrew);
+  const cluster = heb.clusters[clusterNum];
+  const clusterHasVowelName = cluster.hasVowelName(vowelName);
+  describe(description, () => {
+    test(`Should cluster have ${vowelName}? ${result}`, () => {
+      expect(clusterHasVowelName).toEqual(result);
+    });
+  });
+});
+
+describe.each`
   description                                                     | original           | sylArr                               | isMaterArr
   ${"hiriq-yod, one syllable"}                                    | ${"פִּי"}          | ${["פִּי"]}                          | ${[false, true]}
   ${"hiriq-yod, two syllables"}                                   | ${"קָטִיל"}        | ${["קָ", "טִיל"]}                    | ${[false, false, true, false]}
@@ -55,6 +109,25 @@ describe.each`
 });
 
 describe.each`
+  description                                 | hebrew         | clusterNum | isShureq
+  ${"mid-word shureq"}                        | ${"קוּם"}      | ${1}       | ${true}
+  ${"mid-word vav dagesh with vowel"}         | ${"שִׁוֵּק"}   | ${1}       | ${false}
+  ${"mid-word vav dagesh with vowel before"}  | ${"שִׁוּוּק"}  | ${1}       | ${false}
+  ${"mid-word shureq with vav dagesh before"} | ${"שִׁוּוּק"}  | ${2}       | ${true}
+  ${"mid-word vav dagesh with sheva"}         | ${"מְצַוְּךָ"} | ${2}       | ${false}
+  ${"final vav dagesh with vowel before"}     | ${"גֵּוּ"}     | ${1}       | ${false}
+`("isShureq:", ({ description, hebrew, clusterNum, isShureq }) => {
+  const heb = new Text(hebrew);
+  const cluster = heb.clusters[clusterNum];
+  const meteg = cluster.isShureq;
+  describe(description, () => {
+    test(`isShureq to equal ${isShureq}`, () => {
+      expect(meteg).toEqual(isShureq);
+    });
+  });
+});
+
+describe.each`
   description    | hebrew         | clusterNum | isTaam
   ${"meteg"}     | ${"הָאָֽרֶץ׃"} | ${1}       | ${false}
   ${"sof pasuq"} | ${"הָאָֽרֶץ׃"} | ${3}       | ${true}
@@ -65,44 +138,6 @@ describe.each`
   describe(description, () => {
     test(`isTaam to equal ${isTaam}`, () => {
       expect(punc).toEqual(punc);
-    });
-  });
-});
-
-describe.each`
-  description                                        | hebrew              | clusterNum | hasMeteg
-  ${"word with single meteg"}                        | ${"הַֽ֭יְחָבְרְךָ"} | ${0}       | ${true}
-  ${"word with single silluq"}                       | ${"נַפְשִֽׁי׃"}     | ${2}       | ${false}
-  ${"word with meteg & silluq"}                      | ${"הָֽאֲדָמָֽה׃"}   | ${0}       | ${true}
-  ${"word with meteg & silluq"}                      | ${"הָֽאֲדָמָֽה׃"}   | ${3}       | ${false}
-  ${"words with meteg & silluq, joined with maqqef"} | ${"וַֽיְהִי־כֵֽן׃"} | ${0}       | ${true}
-  ${"words with meteg & silluq, joined with maqqef"} | ${"וַֽיְהִי־כֵֽן׃"} | ${5}       | ${false}
-`("hasMeteg:", ({ description, hebrew, clusterNum, hasMeteg }) => {
-  const heb = new Text(hebrew);
-  const cluster = heb.clusters[clusterNum];
-  const meteg = cluster.hasMeteg;
-  describe(description, () => {
-    test(`hasMeteg to equal ${hasMeteg}`, () => {
-      expect(meteg).toEqual(hasMeteg);
-    });
-  });
-});
-
-describe.each`
-  description                                        | hebrew              | clusterNum | hasSilluq
-  ${"word with single meteg"}                        | ${"הַֽ֭יְחָבְרְךָ"} | ${0}       | ${false}
-  ${"word with single silluq"}                       | ${"נַפְשִֽׁי׃"}     | ${2}       | ${true}
-  ${"word with meteg & silluq"}                      | ${"הָֽאֲדָמָֽה׃"}   | ${0}       | ${false}
-  ${"word with meteg & silluq"}                      | ${"הָֽאֲדָמָֽה׃"}   | ${3}       | ${true}
-  ${"words with meteg & silluq, joined with maqqef"} | ${"וַֽיְהִי־כֵֽן׃"} | ${0}       | ${false}
-  ${"words with meteg & silluq, joined with maqqef"} | ${"וַֽיְהִי־כֵֽן׃"} | ${5}       | ${true}
-`("hasSilluq:", ({ description, hebrew, clusterNum, hasSilluq }) => {
-  const heb = new Text(hebrew);
-  const cluster = heb.clusters[clusterNum];
-  const silluq = cluster.hasSilluq;
-  describe(description, () => {
-    test(`hasSilluq to equal ${hasSilluq}`, () => {
-      expect(silluq).toEqual(hasSilluq);
     });
   });
 });
@@ -136,41 +171,6 @@ describe.each`
   describe(description, () => {
     test(`vowel name to equal ${vowelName}`, () => {
       expect(clusterVowelName).toEqual(vowelName);
-    });
-  });
-});
-
-describe.each`
-  description                | hebrew              | clusterNum | vowelName   | result
-  ${"cluster with patah"}    | ${"הַֽ֭יְחָבְרְךָ"} | ${0}       | ${"PATAH"}  | ${true}
-  ${"cluster with qamets"}   | ${"הַֽ֭יְחָבְרְךָ"} | ${0}       | ${"QAMATS"} | ${false}
-  ${"cluster with no vowel"} | ${"י֔וֹם"}          | ${2}       | ${"HOLAM"}  | ${false}
-`("hasVowelName:", ({ description, hebrew, clusterNum, vowelName, result }) => {
-  const heb = new Text(hebrew);
-  const cluster = heb.clusters[clusterNum];
-  const clusterHasVowelName = cluster.hasVowelName(vowelName);
-  describe(description, () => {
-    test(`Should cluster have ${vowelName}? ${result}`, () => {
-      expect(clusterHasVowelName).toEqual(result);
-    });
-  });
-});
-
-describe.each`
-  description                                 | hebrew         | clusterNum | isShureq
-  ${"mid-word shureq"}                        | ${"קוּם"}      | ${1}       | ${true}
-  ${"mid-word vav dagesh with vowel"}         | ${"שִׁוֵּק"}   | ${1}       | ${false}
-  ${"mid-word vav dagesh with vowel before"}  | ${"שִׁוּוּק"}  | ${1}       | ${false}
-  ${"mid-word shureq with vav dagesh before"} | ${"שִׁוּוּק"}  | ${2}       | ${true}
-  ${"mid-word vav dagesh with sheva"}         | ${"מְצַוְּךָ"} | ${2}       | ${false}
-  ${"final vav dagesh with vowel before"}     | ${"גֵּוּ"}     | ${1}       | ${false}
-`("isShureq:", ({ description, hebrew, clusterNum, isShureq }) => {
-  const heb = new Text(hebrew);
-  const cluster = heb.clusters[clusterNum];
-  const meteg = cluster.isShureq;
-  describe(description, () => {
-    test(`isShureq to equal ${isShureq}`, () => {
-      expect(meteg).toEqual(isShureq);
     });
   });
 });

--- a/test/cluster.test.ts
+++ b/test/cluster.test.ts
@@ -1,4 +1,5 @@
 import { Text } from "../src/index";
+import { Cluster } from "../src/cluster";
 
 describe.each`
   description                                        | hebrew              | clusterNum | hasMeteg
@@ -139,6 +140,26 @@ describe.each`
     test(`isTaam to equal ${isTaam}`, () => {
       expect(punc).toEqual(punc);
     });
+  });
+});
+
+describe("syllable:", () => {
+  test("if no syllable, null", () => {
+    const cluster = new Cluster("דָּ");
+    expect(cluster.syllable).toEqual(null);
+  });
+
+  test("cluster text same as syllable text", () => {
+    const text = new Text("דָּבָר");
+    const first = text.clusters[0];
+    expect(first?.syllable?.text).toEqual(first.text);
+  });
+
+  test("cluster text not the same as syllable text", () => {
+    const text = new Text("דָּבָר");
+    const last = text.clusters[text.clusters.length - 1];
+    expect(last?.syllable?.text).not.toEqual("ר");
+    expect(last?.syllable?.text).toEqual("בָר");
   });
 });
 

--- a/test/syllable.test.ts
+++ b/test/syllable.test.ts
@@ -1,3 +1,4 @@
+import { Cluster } from "../src/cluster";
 import { Text } from "../src/index";
 import { Syllable } from "../src/syllable";
 
@@ -127,5 +128,25 @@ describe.each`
     test(`vowelName to equal ${vowelName}`, () => {
       expect(syllableVowelName).toEqual(vowelName);
     });
+  });
+});
+
+describe("word:", () => {
+  test("if no word, null", () => {
+    const clusters = [new Cluster("דָּ")];
+    const syllable = new Syllable(clusters);
+    expect(syllable.word).toEqual(null);
+  });
+
+  test("syllable text same as word text", () => {
+    const text = new Text("זֶה");
+    const first = text.syllables[0];
+    expect(first?.word?.text).toEqual(first.text);
+  });
+
+  test("syllable text not the same as word text", () => {
+    const text = new Text("דָּבָר");
+    const last = text.syllables[text.syllables.length - 1];
+    expect(last?.word?.text).not.toEqual("דָּ");
   });
 });

--- a/test/syllable.test.ts
+++ b/test/syllable.test.ts
@@ -2,37 +2,18 @@ import { Text } from "../src/index";
 import { Syllable } from "../src/syllable";
 
 describe.each`
-  description                     | hebrew              | syllableNum | vowel         | allowNoNiqqud
-  ${"syllable with patah"}        | ${"הַֽ֭יְחָבְרְךָ"} | ${0}        | ${"\u{05B7}"} | ${false}
-  ${"syllable with sheva"}        | ${"הַֽ֭יְחָבְרְךָ"} | ${1}        | ${"\u{05B0}"} | ${false}
-  ${"syllable with silent sheva"} | ${"הַֽ֭יְחָבְרְךָ"} | ${2}        | ${"\u{05B8}"} | ${false}
-  ${"syllable with none"}         | ${"test"}           | ${0}        | ${null}       | ${true}
-`("vowel:", ({ description, hebrew, syllableNum, vowel, allowNoNiqqud }) => {
-  // normally don't use `allowNoNiqqud` in testing, but needed to get `null`
-  const heb = new Text(hebrew, { allowNoNiqqud });
+  description                                          | hebrew         | syllableNum | codaWithGemination
+  ${"open syllable followed by gemination"}            | ${"מַדּוּעַ"}  | ${0}        | ${"דּ"}
+  ${"open syllable followed by no gemination"}         | ${"מֶלֶךְ"}    | ${0}        | ${""}
+  ${"closed syllable followed by dagesh qal"}          | ${"מַסְגֵּר"}  | ${0}        | ${"סְ"}
+  ${"open syllable with sheva followed by dagesh qal"} | ${"שְׁתַּיִם"} | ${0}        | ${""}
+`("codaWithGemination:", ({ description, hebrew, syllableNum, codaWithGemination }) => {
+  const heb = new Text(hebrew);
   const syllable = heb.syllables[syllableNum];
-  const syllableVowel = syllable.vowel;
+  const syllableCodaWithGemination = syllable.codaWithGemination;
   describe(description, () => {
-    test(`vowel to equal ${vowel}`, () => {
-      expect(syllableVowel).toEqual(vowel);
-    });
-  });
-});
-
-describe.each`
-  description                     | hebrew              | syllableNum | vowelName   | allowNoNiqqud
-  ${"syllable with patah"}        | ${"הַֽ֭יְחָבְרְךָ"} | ${0}        | ${"PATAH"}  | ${false}
-  ${"syllable with sheva"}        | ${"הַֽ֭יְחָבְרְךָ"} | ${1}        | ${"SHEVA"}  | ${false}
-  ${"syllable with silent sheva"} | ${"הַֽ֭יְחָבְרְךָ"} | ${2}        | ${"QAMATS"} | ${false}
-  ${"syllable with none"}         | ${"test"}           | ${0}        | ${null}     | ${true}
-`("vowelName:", ({ description, hebrew, syllableNum, vowelName, allowNoNiqqud }) => {
-  // normally don't use `allowNoNiqqud` in testing, but needed to get `null`
-  const heb = new Text(hebrew, { allowNoNiqqud });
-  const syllable = heb.syllables[syllableNum];
-  const syllableVowelName = syllable.vowelName;
-  describe(description, () => {
-    test(`vowelName to equal ${vowelName}`, () => {
-      expect(syllableVowelName).toEqual(vowelName);
+    test(`codaWithGemination to equal ${codaWithGemination}`, () => {
+      expect(syllableCodaWithGemination).toEqual(codaWithGemination);
     });
   });
 });
@@ -66,6 +47,25 @@ describe.each`
 });
 
 describe.each`
+  description               | hebrew                 | syllableNum | nextExists | nextText
+  ${"has next"}             | ${"הַֽ֭יְחָבְרְךָ"}    | ${0}        | ${true}    | ${"יְ"}
+  ${"does not have next"}   | ${"כִּסֵּ֣א"}          | ${1}        | ${false}   | ${null}
+  ${"does not cross words"} | ${"כִּסֵּ֣א הַוּ֑וֹת"} | ${1}        | ${false}   | ${null}
+`("implements Node:", ({ description, hebrew, syllableNum, nextExists, nextText }) => {
+  const heb = new Text(hebrew);
+  const syllable = heb.syllables[syllableNum];
+  const nextSyllable = syllable.next;
+  describe(description, () => {
+    test(`${description}`, () => {
+      expect(nextSyllable).toBeDefined();
+      if (nextExists && nextSyllable && nextSyllable instanceof Syllable) {
+        expect(nextSyllable.text).toEqual(nextText);
+      }
+    });
+  });
+});
+
+describe.each`
   description                                    | hebrew             | syllableNum | onset   | nucleus               | coda
   ${"closed syllable"}                           | ${"יָ֥ם"}          | ${0}        | ${"י"}  | ${"\u{05B8}\u{05A5}"} | ${"ם"}
   ${"open syllable"}                             | ${"מַדּוּעַ"}      | ${0}        | ${"מ"}  | ${"\u{05B7}"}         | ${""}
@@ -95,37 +95,37 @@ describe.each`
 });
 
 describe.each`
-  description                                          | hebrew         | syllableNum | codaWithGemination
-  ${"open syllable followed by gemination"}            | ${"מַדּוּעַ"}  | ${0}        | ${"דּ"}
-  ${"open syllable followed by no gemination"}         | ${"מֶלֶךְ"}    | ${0}        | ${""}
-  ${"closed syllable followed by dagesh qal"}          | ${"מַסְגֵּר"}  | ${0}        | ${"סְ"}
-  ${"open syllable with sheva followed by dagesh qal"} | ${"שְׁתַּיִם"} | ${0}        | ${""}
-`("codaWithGemination:", ({ description, hebrew, syllableNum, codaWithGemination }) => {
-  const heb = new Text(hebrew);
+  description                     | hebrew              | syllableNum | vowel         | allowNoNiqqud
+  ${"syllable with patah"}        | ${"הַֽ֭יְחָבְרְךָ"} | ${0}        | ${"\u{05B7}"} | ${false}
+  ${"syllable with sheva"}        | ${"הַֽ֭יְחָבְרְךָ"} | ${1}        | ${"\u{05B0}"} | ${false}
+  ${"syllable with silent sheva"} | ${"הַֽ֭יְחָבְרְךָ"} | ${2}        | ${"\u{05B8}"} | ${false}
+  ${"syllable with none"}         | ${"test"}           | ${0}        | ${null}       | ${true}
+`("vowel:", ({ description, hebrew, syllableNum, vowel, allowNoNiqqud }) => {
+  // normally don't use `allowNoNiqqud` in testing, but needed to get `null`
+  const heb = new Text(hebrew, { allowNoNiqqud });
   const syllable = heb.syllables[syllableNum];
-  const syllableCodaWithGemination = syllable.codaWithGemination;
+  const syllableVowel = syllable.vowel;
   describe(description, () => {
-    test(`codaWithGemination to equal ${codaWithGemination}`, () => {
-      expect(syllableCodaWithGemination).toEqual(codaWithGemination);
+    test(`vowel to equal ${vowel}`, () => {
+      expect(syllableVowel).toEqual(vowel);
     });
   });
 });
 
 describe.each`
-  description               | hebrew                 | syllableNum | nextExists | nextText
-  ${"has next"}             | ${"הַֽ֭יְחָבְרְךָ"}    | ${0}        | ${true}    | ${"יְ"}
-  ${"does not have next"}   | ${"כִּסֵּ֣א"}          | ${1}        | ${false}   | ${null}
-  ${"does not cross words"} | ${"כִּסֵּ֣א הַוּ֑וֹת"} | ${1}        | ${false}   | ${null}
-`("implements Node:", ({ description, hebrew, syllableNum, nextExists, nextText }) => {
-  const heb = new Text(hebrew);
+  description                     | hebrew              | syllableNum | vowelName   | allowNoNiqqud
+  ${"syllable with patah"}        | ${"הַֽ֭יְחָבְרְךָ"} | ${0}        | ${"PATAH"}  | ${false}
+  ${"syllable with sheva"}        | ${"הַֽ֭יְחָבְרְךָ"} | ${1}        | ${"SHEVA"}  | ${false}
+  ${"syllable with silent sheva"} | ${"הַֽ֭יְחָבְרְךָ"} | ${2}        | ${"QAMATS"} | ${false}
+  ${"syllable with none"}         | ${"test"}           | ${0}        | ${null}     | ${true}
+`("vowelName:", ({ description, hebrew, syllableNum, vowelName, allowNoNiqqud }) => {
+  // normally don't use `allowNoNiqqud` in testing, but needed to get `null`
+  const heb = new Text(hebrew, { allowNoNiqqud });
   const syllable = heb.syllables[syllableNum];
-  const nextSyllable = syllable.next;
+  const syllableVowelName = syllable.vowelName;
   describe(description, () => {
-    test(`${description}`, () => {
-      expect(nextSyllable).toBeDefined();
-      if (nextExists && nextSyllable && nextSyllable instanceof Syllable) {
-        expect(nextSyllable.text).toEqual(nextText);
-      }
+    test(`vowelName to equal ${vowelName}`, () => {
+      expect(syllableVowelName).toEqual(vowelName);
     });
   });
 });


### PR DESCRIPTION
## What this does

This branch adds access to the "parent" object from the child.

- `Char` has access to `Cluster`
- `Cluster` has access to `Syllable`
- `Syllable` has access to `Word`

The only exception is that there is no `Text` parent on the `Word` class. Because

- the properties on the `Text` class is only its children
- having `Word.text` and `Word.Text` would be confusing

## Example

```js
new Text("דָּבָר").clusters[1].syllable.isClosed;
 // true
```
Now the `Cluster` has access to knowledge about the `Syllable`

## Why

Primarily to feed into the transliteration package so when using a  callback the user can access the parent.