### PR TITLE
Fix stress

### DIFF
--- a/src/utils/syllabifier.ts
+++ b/src/utils/syllabifier.ts
@@ -514,7 +514,7 @@ const reinsertLatin = (syls: Syllable[], latin: { cluster: Cluster; pos: number 
   return syls;
 };
 
-export const syllabify = (clusters: Cluster[], options: SylOpts): Syllable[] => {
+export const syllabify = (clusters: Cluster[], options: SylOpts, isWordInConstruct: boolean): Syllable[] => {
   const removeLatin = clusters.filter((cluster) => !cluster.isNotHebrew);
   const latinClusters = clusters.map(clusterPos).filter((c) => c.cluster.isNotHebrew);
   const groupedClusters = groupClusters(removeLatin, options);
@@ -530,7 +530,8 @@ export const syllabify = (clusters: Cluster[], options: SylOpts): Syllable[] => 
   syllables.forEach(setIsAccented);
 
   // if there is no accented syllable, then the last syllable is accented
-  if (!syllables.map((s) => s.isAccented).includes(true)) {
+  // unless that syllable is part of a word in construct
+  if (!syllables.map((s) => s.isAccented).includes(true) && !isWordInConstruct) {
     syllables[syllables.length - 1].isAccented = true;
   }
 

--- a/src/word.ts
+++ b/src/word.ts
@@ -142,7 +142,7 @@ export class Word {
       return [syl];
     }
 
-    const syllables = syllabify(this.clusters, this.sylOpts);
+    const syllables = syllabify(this.clusters, this.sylOpts, this.isInConstruct);
     syllables.forEach((syl) => (syl.word = this));
 
     return syllables;

--- a/test/syllable.isAccented.test.ts
+++ b/test/syllable.isAccented.test.ts
@@ -14,6 +14,10 @@ describe("Test if a syllable is accented", () => {
     testIsAccented("דָּבָר", [false, true]);
   });
 
+  test("If in construct, no accent", () => {
+    testIsAccented("כָּל־הָעָ֖ם", [false, false, true]);
+  });
+
   describe("Taamim that fall on the stressed syllable", () => {
     test("silluq", () => {
       testIsAccented("חֽוּשָׁה׃", [true, false]);


### PR DESCRIPTION
Removes stress from final syllable when the Word is in construct.

e.g.

```js
new Text("כָּל־הָעָ֖ם").syllables.map((s) => s.isAccented);
// [ false, false, true ]
```