### PR TITLE
Sheva identical consonants

### DIFF
--- a/src/utils/syllabifier.ts
+++ b/src/utils/syllabifier.ts
@@ -120,7 +120,18 @@ const groupShevas = (arr: Mixed, options: SylOpts): Mixed => {
     }
 
     const clusterHasSheva = cluster.hasSheva;
-    if (!shevaPresent && clusterHasSheva) {
+    const consonant = cluster.chars[0].text;
+    const prevConsonant = arr[index - 1]?.chars[0].text || "";
+    const nextClusterVowel = arr[index + 1];
+    // We also need to check if this cluster and the previous cluster are different consonants
+    // because if they are the same consonant (and the previous vowel is not short), then the sheva will be vocal.
+    // e.g. "סָבְב֥וּ" is [ 'סָ', 'בְ', 'ב֥וּ' ], but "הִנְנִי֩" is [ 'הִנְ', 'נִי֩' ] b/c of the short vowel.
+    // Also remember that prev and next are switched because we are iterating backwards.
+    if (
+      !shevaPresent &&
+      clusterHasSheva &&
+      (consonant !== prevConsonant || (nextClusterVowel instanceof Cluster && nextClusterVowel.hasShortVowel))
+    ) {
       shevaPresent = true;
       syl.unshift(cluster);
       continue;

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -81,15 +81,17 @@ describe.each`
 });
 
 describe.each`
-  description              | word           | syllables                | isClosedArr              | longVowelsOpt | qametsQatanOpt
-  ${"regular qamets"}      | ${"יָדְךָ"}    | ${["יָ", "דְ", "ךָ"]}    | ${[false, false, false]} | ${true}       | ${true}
-  ${"regular qamets"}      | ${"יָדְךָ"}    | ${["יָדְ", "ךָ"]}        | ${[true, false]}         | ${false}      | ${true}
-  ${"qamets qatan"}        | ${"חָפְנִי"}   | ${["חׇפְ", "נִי"]}       | ${[true, false]}         | ${true}       | ${true}
-  ${"qamets qatan"}        | ${"חָפְנִי"}   | ${["חׇפְ", "נִי"]}       | ${[true, false]}         | ${false}      | ${true}
-  ${"qamets qatan"}        | ${"חָפְנִי"}   | ${["חָ", "פְ", "נִי"]}   | ${[false, false, false]} | ${true}       | ${false}
-  ${"qamets qatan"}        | ${"חָפְנִי"}   | ${["חָפְ", "נִי"]}       | ${[true, false]}         | ${false}      | ${false}
-  ${"holem male"}          | ${"הוֹלְכִים"} | ${["הֹו", "לְ", "כִים"]} | ${[false, false, true]}  | ${true}       | ${true}
-  ${"holem male w/ false"} | ${"הוֹלְכִים"} | ${["הֹולְ", "כִים"]}     | ${[true, true]}          | ${false}      | ${true}
+  description                                                       | word           | syllables                | isClosedArr              | longVowelsOpt | qametsQatanOpt
+  ${"regular qamets"}                                               | ${"יָדְךָ"}    | ${["יָ", "דְ", "ךָ"]}    | ${[false, false, false]} | ${true}       | ${true}
+  ${"regular qamets"}                                               | ${"יָדְךָ"}    | ${["יָדְ", "ךָ"]}        | ${[true, false]}         | ${false}      | ${true}
+  ${"qamets qatan"}                                                 | ${"חָפְנִי"}   | ${["חׇפְ", "נִי"]}       | ${[true, false]}         | ${true}       | ${true}
+  ${"qamets qatan"}                                                 | ${"חָפְנִי"}   | ${["חׇפְ", "נִי"]}       | ${[true, false]}         | ${false}      | ${true}
+  ${"qamets qatan"}                                                 | ${"חָפְנִי"}   | ${["חָ", "פְ", "נִי"]}   | ${[false, false, false]} | ${true}       | ${false}
+  ${"qamets qatan"}                                                 | ${"חָפְנִי"}   | ${["חָפְ", "נִי"]}       | ${[true, false]}         | ${false}      | ${false}
+  ${"holem male"}                                                   | ${"הוֹלְכִים"} | ${["הֹו", "לְ", "כִים"]} | ${[false, false, true]}  | ${true}       | ${true}
+  ${"holem male w/ false"}                                          | ${"הוֹלְכִים"} | ${["הֹולְ", "כִים"]}     | ${[true, true]}          | ${false}      | ${true}
+  ${"sheva after long vowel and under two indentical consonants"}   | ${"סָבְב֥וּ"}  | ${["סָ", "בְ", "ב֥וּ"]}  | ${[false, false, false]} | ${false}      | ${true}
+  ${"sheva after short vowel and under two  indentical consonants"} | ${"הִנְנִי֩"}  | ${["הִנְ", "נִי֩"]}      | ${[true, false]}         | ${false}      | ${true}
 `("longVowels:", ({ description, word, syllables, isClosedArr, longVowelsOpt, qametsQatanOpt }) => {
   const text = new Text(word, { longVowels: longVowelsOpt, qametsQatan: qametsQatanOpt });
   const sylText = text.syllables.map((syl) => syl.text);


### PR DESCRIPTION
Ensures when a sheva is under a pair of identical consonants (e.g. סָבְב֥וּ) it is vocal, unless the vowel is short (e.g. הִנְנִי֩).