### PR TITLE
Warn instead of throw if a syllable is preceding a Cluster with a Mater.

### DIFF
--- a/src/utils/syllabifier.ts
+++ b/src/utils/syllabifier.ts
@@ -256,7 +256,7 @@ const groupMaters = (arr: Mixed, strict: boolean = true): Mixed => {
 
       if (nxt instanceof Syllable) {
         const word = arr.map((i) => i.text).join("");
-        throw new Error(`Syllable ${nxt.text} should not precede a Cluster with a Mater in ${word}`);
+        console.warn(`Syllable ${nxt.text} should not precede a Cluster with a Mater in ${word}`);
       }
 
       if (nxt) syl.unshift(nxt);


### PR DESCRIPTION
Hi Charles! Thanks for all the incredible work. This is just a suggestion based on personal usage. תְִּירָא֑וּם ("tî·rā·’ūm" found in Deut.3.22) is currently throwing an error when attempting to parse it. Simply logging a warning instead of throwing an error seemed to resolve all issues. 

Here are three links to use for reference:

https://www.sefaria.org/Deuteronomy.3.22?lang=bi&with=all&lang2=en

https://biblehub.com/interlinear/deuteronomy/3-22.htm

https://www.stepbible.org/?q=version=MapM|reference=Deu.3.22