### PR TITLE
Sheva with meteg

### DIFF
--- a/src/text.ts
+++ b/src/text.ts
@@ -150,6 +150,29 @@ export interface SylOpts {
    */
   shevaAfterMeteg?: boolean;
   /**
+   * determines whether to regard a sheva with a meteg as a _sheva na'_. This is also called a sheva ga'ya.
+   *
+   * @defaultValue true
+   * @example
+   * ```ts
+   * const usingDefault = new Text("אַ֥שְֽׁרֵי");
+   * usingDefault.syllables.map((s) => ({ text: s.text, isClosed: s.isClosed }));
+   * // [
+   * //  { text: 'אַ֥', isClosed: false },
+   * //  { text: 'שְֽׁ', isClosed: false },
+   * //  { text: 'רֵי', isClosed: false }
+   * // ]
+   *
+   * const optional = new Text("אַ֥שְֽׁרֵי", { shevaWithMeteg: false });
+   * optional.syllables.map((s) => ({ text: s.text, isClosed: s.isClosed }));
+   * // [
+   * //  { text: 'אַ֥שְֽׁ', isClosed: true },
+   * //  { text: 'רֵי', isClosed: false }
+   * // ]
+   * ```
+   */
+  shevaWithMeteg?: boolean;
+  /**
    * determines whether to regard the sheva under the letters שׁשׂסצנמלוי when preceded by a waw-consecutive with a missing dagesh chazaq as a _sheva na'_, unless preceded by a meteg (see {@link shevaAfterMeteg}).
    *
    * @defaultValue true
@@ -244,6 +267,7 @@ export class Text {
       "longVowels",
       "qametsQatan",
       "shevaAfterMeteg",
+      "shevaWithMeteg",
       "sqnmlvy",
       "strict",
       "wawShureq"
@@ -271,6 +295,7 @@ export class Text {
       longVowels: validOpts.longVowels ?? true,
       qametsQatan: validOpts.qametsQatan ?? true,
       shevaAfterMeteg: validOpts.shevaAfterMeteg ?? true,
+      shevaWithMeteg: validOpts.shevaWithMeteg ?? true,
       sqnmlvy: validOpts.sqnmlvy ?? true,
       strict: validOpts.strict ?? true,
       wawShureq: validOpts.wawShureq ?? true

--- a/src/utils/syllabifier.ts
+++ b/src/utils/syllabifier.ts
@@ -120,6 +120,12 @@ const groupShevas = (arr: Mixed, options: SylOpts): Mixed => {
     }
 
     const clusterHasSheva = cluster.hasSheva;
+
+    if (clusterHasSheva && cluster.hasMeteg && options.shevaWithMeteg) {
+      syl.unshift(cluster);
+      syl = shevaNewSyllable(syl);
+      continue;
+    }
     const consonant = cluster.chars[0].text;
     const prevConsonant = arr[index - 1]?.chars[0].text || "";
     const nextClusterVowel = arr[index + 1];

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -275,6 +275,25 @@ describe.each`
 );
 
 describe.each`
+  description                  | word            | syllables                 | isClosedArr              | shevaWithMetegOpt
+  ${"medial sheva with meteg"} | ${"אַ֥שְֽׁרֵי"} | ${["אַ֥שְֽׁ", "רֵי"]}     | ${[true, false]}         | ${false}
+  ${"medial sheva with meteg"} | ${"אַ֥שְֽׁרֵי"} | ${["אַ֥", "שְֽׁ", "רֵי"]} | ${[false, false, false]} | ${true}
+`("shevaWithMeteg:", ({ description, word, syllables, isClosedArr, shevaWithMetegOpt }) => {
+  const text = new Text(word, { shevaWithMeteg: shevaWithMetegOpt });
+  const sylText = text.syllables.map((syl) => syl.text);
+  const isClosed = text.syllables.map((syl) => syl.isClosed);
+  describe(description, () => {
+    test(`shevaWithMeteg is ${shevaWithMetegOpt}`, () => {
+      expect(sylText).toEqual(syllables);
+    });
+
+    test(`isClosed`, () => {
+      expect(isClosed).toEqual(isClosedArr);
+    });
+  });
+});
+
+describe.each`
   description                            | word                | strict
   ${"threw hasShortVowel error"}         | ${"אלִי"}           | ${true}
   ${"threw hasShortVowel error"}         | ${"אלִי"}           | ${false}


### PR DESCRIPTION
Add an option for when a sheva has a meteg to mark the sheva as a vowel. See Khan _TPT_ 1.2.9 Shewa Ga'ya