### PR TITLE
Add logic for only alone

### DIFF
--- a/src/utils/syllabifier.ts
+++ b/src/utils/syllabifier.ts
@@ -495,9 +495,22 @@ const setIsAccented = (syllable: Syllable) => {
   }
 
   // ole-weyored, the ole does not take the accent, only the "yored" (i.e. a merkha)
+  // unless the ole is by itself
   const ole = /\u{05AB}/u;
   if (ole.test(syllable.text)) {
-    syllable.isAccented = false;
+    const yored = /\u{05A5}/u;
+    let next = syllable.next?.value;
+
+    while (next) {
+      if (yored.test(next.text)) {
+        next.isAccented = true;
+        syllable.isAccented = false;
+        return;
+      }
+      next = (next?.next?.value as Syllable) ?? null;
+    }
+
+    syllable.isAccented = true;
     return;
   }
 

--- a/test/syllable.isAccented.test.ts
+++ b/test/syllable.isAccented.test.ts
@@ -195,9 +195,15 @@ describe("Test if a syllable is accented", () => {
           });
         });
 
-        test("ole-weyored", () => {
-          // only the ole is prepositive
-          testIsAccented("רְשָׁ֫עִ֥ים", [false, false, true]);
+        describe("ole-weyored", () => {
+          test("ole-weyored", () => {
+            // only the ole is prepositive
+            testIsAccented("רְשָׁ֫עִ֥ים", [false, false, true]);
+          });
+
+          test("ole alone", () => {
+            testIsAccented("טַ֫עַם", [true, false]);
+          });
         });
 
         describe("dechi", () => {


### PR DESCRIPTION
When an ole is by itself (e.g. טַ֫עַם) that is used to mark the accent